### PR TITLE
Candidate fix for stageid issue where stageid tries to be updated from undefined to undefined

### DIFF
--- a/src/prettifyWebApi.js
+++ b/src/prettifyWebApi.js
@@ -2083,6 +2083,10 @@
         window.pfwaMode = isCreateMode ? 'create' : 'read';
         if (window.originalResponseCopy == null) {
             window.originalResponseCopy = JSON.parse(JSON.stringify(jsonObj));
+            //stageid being deprecated but fieldname in metadata doesn't match the json field name, so is a special case. Ensure json property name matches logical name
+            if (Object.hasOwn(window.originalResponseCopy, '_stageid_value') && !Object.hasOwn(window.originalResponseCopy, 'stageid')) {
+                window.originalResponseCopy['stageid'] = window.originalResponseCopy['_stageid_value'];
+            }
         }
 
         const isMultiple = (jsonObj.value && Array.isArray(jsonObj.value));


### PR DESCRIPTION
The issues is that stageid returned within json is called `_stageid_value` and thus the value was undefined when we tried to reach it by attribute logical name: `stageid`

Only tested that it doesn't interfere with other field updates where one would get an error because it tries to set it to a undefined value. Not sure if this field is updateable. Could be a concern for CRMv8 users. However this PR is already an improvement in any case.